### PR TITLE
fix (webdriver detection): Prevent detection

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -8,6 +8,7 @@
   "glob_photo_path": "/path/to/photos/",
   "glob_ad_prefix": "Text to add which comes before the actual ad description.\nLeave free if not needed\n",
   "glob_ad_suffix": "Text to add which comes after the actual ad description.\nLeave free if not needed\n",
+  "webdriver_enabled": false,
   "ads": [
     { "title": "Example 1",
       "desc": "... with a negotiable price (5 EUR) and some photos.",

--- a/kleinanzeigen.py
+++ b/kleinanzeigen.py
@@ -392,6 +392,10 @@ def session_create(config):
     if config.get('headless', False) is True:
         log.info("Headless mode")
         options.add_argument("--headless")
+
+    if config.get('webdriver_enabled') is False:
+        options.set_preference("dom.webdriver.enabled", False)
+    
     driver = webdriver.Firefox(options=options)
 
     log.info("New session is: %s %s" % (driver.session_id, driver.command_executor._url))


### PR DESCRIPTION
The kleinanzeigen started to detect the webdriver.
At the moment no automated login is possible.

This commit adds configuration to set the webdriver disabled,
and prevent detection of automation.