### PR TITLE
Fix for regular input fields (additional_category_options)

### DIFF
--- a/kleinanzeigen.py
+++ b/kleinanzeigen.py
@@ -251,7 +251,10 @@ def post_ad(driver, ad, interactive):
             )
             Select(select_element).select_by_visible_text(value)
         except NoSuchElementException:
-            pass
+            try:
+                driver.find_element_by_xpath("//input[@id='%s']" % element_id).send_keys(value)
+            except NoSuchElementException:
+                pass
 
 
     text_area = driver.find_element_by_id("pstad-descrptn")


### PR DESCRIPTION
Some categories don't use dropdowns for some of the additional category options. This new fallback makes such categories work.