### PR TITLE
Support for ad type "WANTED" 

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -11,7 +11,9 @@
   "webdriver_enabled": false,
   "update_interval": 30, // number of days an ad has to be old in order to be reposted
   "ads": [
-    { "title": "Example 1",
+    {
+      "type": "OFFER",
+      "title": "Example 1",
       "desc": "... with a negotiable price (5 EUR) and some photos.",
       "enabled": "1",
       "price": "5",
@@ -21,7 +23,9 @@
       "photofiles": [ "file1.jpg", "file2.jpg" ],
       "zip" : "33333"
     },
-    { "title": "Example 2",
+    {
+      "type": "WANTED",
+      "title": "Example 2",
       "description_file" : "/abspath/to/file.txt", // will not read contents of "desc"
       "enabled": "1",
       "price": "10",

--- a/kleinanzeigen.py
+++ b/kleinanzeigen.py
@@ -217,7 +217,7 @@ def post_ad(driver, ad, interactive):
         return fRc
 
     # Fill form
-    if ad["type"] == "WANTED":
+    if "type" in ad and ad["type"] == "WANTED":
         driver.find_element_by_id('adType2').click()
     title_input = driver.find_element_by_id('postad-title')
     title_input.click()

--- a/kleinanzeigen.py
+++ b/kleinanzeigen.py
@@ -217,6 +217,8 @@ def post_ad(driver, ad, interactive):
         return fRc
 
     # Fill form
+    if ad["type"] == "WANTED":
+        driver.find_element_by_id('adType2').click()
     title_input = driver.find_element_by_id('postad-title')
     title_input.click()
     title_input.send_keys(ad["title"])


### PR DESCRIPTION
This change adds basic control for the ad type. Type "OFFER" was added to the example config only for the sake of completeness. It's not required or used in code currently, because its radio button is always preselected by default.