### PR TITLE
add no_sandbox config option

### DIFF
--- a/kleinanzeigen.py
+++ b/kleinanzeigen.py
@@ -429,6 +429,10 @@ def session_create(config):
         log.info("Headless mode")
         options.add_argument("--headless")
 
+    if config.get('no_sandbox', False) is True:
+        log.info("No Sandbox mode")
+        options.add_argument('--no-sandbox')
+
     if os.path.isfile("./chrome-win/chrome.exe"):
         log.info("Found ./chrome-win/chrome.exe")
         options.binary_location = "./chrome-win/chrome.exe"


### PR DESCRIPTION
Passing "--no-sandbox" option prevents Chrome Driver from crashing with `DevToolsActivePort file doesn't exist` in some environment.